### PR TITLE
fix: Added eslint-plugin-react-hooks to react package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2306,6 +2306,17 @@
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
       }
     },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
+      "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      }
+    },
     "node_modules/eslint-plugin-react/node_modules/doctrine": {
       "version": "2.1.0",
       "license": "Apache-2.0",
@@ -7979,7 +7990,7 @@
     },
     "packages/core": {
       "name": "@moser-inc/eslint-config",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "ISC",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^5.27.0",
@@ -7995,19 +8006,20 @@
     },
     "packages/react": {
       "name": "@moser-inc/eslint-config-react",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "ISC",
       "dependencies": {
-        "@moser-inc/eslint-config": "1.3.1",
-        "eslint-plugin-react": "^7.30.0"
+        "@moser-inc/eslint-config": "1.3.2",
+        "eslint-plugin-react": "^7.30.0",
+        "eslint-plugin-react-hooks": "^4.6.0"
       }
     },
     "packages/vue": {
       "name": "@moser-inc/eslint-config-vue",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "ISC",
       "dependencies": {
-        "@moser-inc/eslint-config": "1.3.1",
+        "@moser-inc/eslint-config": "1.3.2",
         "@vue/eslint-config-prettier": "^7.0.0",
         "@vue/eslint-config-typescript": "^10.0.0",
         "eslint-import-resolver-alias": "^1.1.2",
@@ -8241,14 +8253,15 @@
     "@moser-inc/eslint-config-react": {
       "version": "file:packages/react",
       "requires": {
-        "@moser-inc/eslint-config": "1.3.1",
-        "eslint-plugin-react": "^7.30.0"
+        "@moser-inc/eslint-config": "1.3.2",
+        "eslint-plugin-react": "^7.30.0",
+        "eslint-plugin-react-hooks": "*"
       }
     },
     "@moser-inc/eslint-config-vue": {
       "version": "file:packages/vue",
       "requires": {
-        "@moser-inc/eslint-config": "1.3.1",
+        "@moser-inc/eslint-config": "1.3.2",
         "@vue/eslint-config-prettier": "^7.0.0",
         "@vue/eslint-config-typescript": "^10.0.0",
         "eslint-import-resolver-alias": "^1.1.2",
@@ -9498,6 +9511,12 @@
           "version": "6.3.0"
         }
       }
+    },
+    "eslint-plugin-react-hooks": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
+      "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
+      "requires": {}
     },
     "eslint-plugin-vue": {
       "version": "8.7.1",

--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -3,6 +3,7 @@ module.exports = {
     '@moser-inc/eslint-config',
     'plugin:react/recommended',
     'plugin:react/jsx-runtime',
+    'plugin:react-hooks/recommended',
   ],
   settings: {
     react: {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -4,7 +4,8 @@
   "main": "index.js",
   "dependencies": {
     "@moser-inc/eslint-config": "1.3.2",
-    "eslint-plugin-react": "^7.30.0"
+    "eslint-plugin-react": "^7.30.0",
+    "eslint-plugin-react-hooks": "^4.6.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
We were missing the react-hooks plugin, so we weren't getting `useEffect` and similar dependency errors.