### PR TITLE
feat: support import url suffixes

### DIFF
--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -25,6 +25,7 @@ module.exports = {
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/interface-name-prefix': 'off',
     eqeqeq: 'warn',
+    'import/no-unresolved': ['error', { ignore: ['\\?*$'] }],
     'import/order': [
       'error',
       {


### PR DESCRIPTION
Some bundlers (like vite) support appending url params to modify import behavior. This change is required to make sure that does not cause errors.